### PR TITLE
Add CHANGELOG entry for 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+Switch to using native packages for installation. 
+
 # 0.2.2
 
 Removed mysql* dependencies, since they are handled by mysql cookbook.


### PR DESCRIPTION
Pushed new version to supermarket -  https://supermarket.chef.io/cookbooks/openstack-mistral/versions/0.3.0

While doing it I had to edit the changelog - https://supermarket.chef.io/cookbooks/openstack-mistral/versions/0.3.0#changelog. 

So here's a PR so master changelog shows 0.3.0 as well. Thanks to @sysbot, @shortdudey123 and @armab for 0.3.0 changes. I am sure I under sold 0.3.0 changes. If you want to add more to changelog, gfi. 
