### PR TITLE
Bugfix/service notifies

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@stackstorm.com'
 license 'Apache 2.0'
 description 'Installs/Configures openstack-mistral'
 long_description 'Installs/Configures openstack-mistral'
-version '0.3.0'
+version '0.3.1'
 
 depends 'packagecloud'
 depends 'database'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,7 @@ template '/etc/mistral/mistral.conf' do
   )
   mode '0644'
   action :create
-  notifies :reload, 'service[mistral]', :delayed
-  notifies :reload, 'service[mistral-api]', :delayed
-  notifies :reload, 'service[mistral-server]', :delayed
+  notifies :restart, 'service[mistral]', :delayed
+  notifies :restart, 'service[mistral-api]', :delayed
+  notifies :restart, 'service[mistral-server]', :delayed
 end


### PR DESCRIPTION
Update service notifications to use `:restart` instead of `:reload`.

Closes #5
