### PR TITLE
Deprecate chef-openstack-mistral

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **DEPRECATED!**  
+> `Mistral` is deprecated since StackStorm`v3.3.0` in favor of [Orquesta](https://docs.stackstorm.com/orquesta/index.html), a self-grown StackStorm workflow Engine.
+
+
 # OpenStack Mistral chef cookbook
 
 [cookbook]: https://github.com/StackStorm/chef-openstack-mistral


### PR DESCRIPTION
Deprecate and archive this repo https://github.com/StackStorm/chef-openstack-mistral as st2 `v3.3.0` will come with no `Mistral`.